### PR TITLE
Upgrade lambda module

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,5 @@
 module "lambda" {
-  source = "github.com/claranet/terraform-aws-lambda?ref=v0.8.3"
+  source = "github.com/claranet/terraform-aws-lambda?ref=v0.12.0"
 
   function_name = "${var.name}"
   description   = "Let's Encrypt certificate management"


### PR DESCRIPTION
On newer OSes (like fedora 31) python2 is not installed by default and this module fails with `/usr/bin/env: ‘python2’: No such file or directory` errors.
`v0.12.0` does not enforce python2 as an interpreter in python scripts.